### PR TITLE
Allow setDefaults after the component is attached

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -280,7 +280,7 @@ class Multiplier extends Container
 			$count = $resolver->getCreateNum();
 			while ($count > 0 && $this->isValidMaxCopies()) {
 				$this->noValidate[] = $containers[] = $container = $this->addCopy();
-                $container->setValues($this->createContainer()->getValues());
+				$container->setValues($this->createContainer()->getValues());
 				$count--;
 			}
 		}
@@ -487,6 +487,16 @@ class Multiplier extends Container
 	{
 		$this->values = $values;
 		$this->erase = $erase;
+
+		if ($this->created) {
+			foreach ($this->getContainers() as $container) {
+				$this->removeComponent($container);
+			}
+
+			$this->created = false;
+			$this->detachCreateButtons();
+			$this->createCopies();
+		}
 
 		return $this;
 	}

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -228,7 +228,6 @@ class Multiplier extends Container
 		}
 
 		$container = $this->createContainer();
-		$this->fillContainer($container);
 		if ($defaults) {
 			$container->setDefaults($defaults, $this->erase);
 		}
@@ -267,7 +266,6 @@ class Multiplier extends Container
 			$copyNumber = $this->copyNumber;
 			while ($copyNumber > 0 && $this->isValidMaxCopies()) {
 				$containers[] = $container = $this->addCopy();
-				$this->applyDefaultValues($container);
 				$copyNumber--;
 			}
 		}
@@ -282,7 +280,7 @@ class Multiplier extends Container
 			$count = $resolver->getCreateNum();
 			while ($count > 0 && $this->isValidMaxCopies()) {
 				$this->noValidate[] = $containers[] = $container = $this->addCopy();
-				$this->applyDefaultValues($container);
+                $container->setValues($this->createContainer()->getValues());
 				$count--;
 			}
 		}
@@ -366,20 +364,6 @@ class Multiplier extends Container
 		}
 	}
 
-	protected function applyDefaultValues(Container $container): void
-	{
-		$form = new Form('_foo_multiplier');
-		$factoryContainer = $form->addContainer('foo');
-		$this->fillContainer($factoryContainer);
-
-		foreach ($factoryContainer->getControls() as $name => $control) {
-			/** @var IControl $component */
-			$component = $container->getComponent($name, false);
-			if ($component) {
-				$component->setValue($control->getValue());
-			}
-		}
-	}
 
 	protected function createNumber(): int
 	{
@@ -408,6 +392,7 @@ class Multiplier extends Container
 	{
 		$control = new Container();
 		$control->currentGroup = $this->currentGroup;
+		$this->fillContainer($control);
 
 		return $control;
 	}


### PR DESCRIPTION
Hi,
In this PR, I'd like to introduce the possibility to use setDefaults later in the Component model life cycle than in the constructor. Currently it is possible to set values only before the component is attached, which makes the Multiplier a bit tough to use with a typical Nette application life cycle.

With this PR, it is possible to:

```php
class RecipePresenter {

  public function actionDetail($recipeId) {
    $recipe = [
      'name' => 'hot-dog',
      'steps' => [
        ['description' => 'put sausage into boiling water'],
        ['description' => 'make hole into a bread roll'],
        ['description' => 'optional: add ketchup or mustard into bread roll'],
        ['description' => 'insert sausage'],
      ]
    ];
    $form = $this['recipeForm'];
    $form->setDefaults($recipe);
  }

  public function createComponentRecipeForm() {
    $form = new Form();
    $form->addText('title', 'Recipe name');
    $form->addMultiplier('steps', 'Steps', function($container) {
      $container->addTextarea('description');
    });

    return $form;
  }
}
```

Note: The first commit is not neccessary for this PR. As I was investigating, I found out that the removed functionality does not seem to bring any value and with re-initialization in mind, I wanted to reduce needles instances creation