### PR TITLE
Do not throw exception if component is not found

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -399,7 +399,7 @@ class Multiplier extends Container
 	{
 		$buttons = [];
 		foreach ($this->createButtons as $button) {
-			$buttons[$button->getCopyCount()] = $this->getComponent($button->getComponentName());
+			$buttons[$button->getCopyCount()] = $this->getComponent($button->getComponentName(), false);
 		}
 
 		return $buttons;


### PR DESCRIPTION
Adding fields more than maxCopies throws an exception:

```
Nette\InvalidArgumentException
Component with name 'multiplier_creator' does not exist.
```