### PR TITLE
Prevent validation in remove button, make it work

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -305,7 +305,6 @@ class Multiplier extends Container
 		}
 
 		if ($resolver->isRemoveAction() && $this->totalCopies >= $this->minCopies && !$resolver->reachedMinLimit()) {
-
 			$this->form->setSubmittedBy($this->removeButton->create($this));
 
 			$this->resetFormEvents();

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -305,6 +305,9 @@ class Multiplier extends Container
 		}
 
 		if ($resolver->isRemoveAction() && $this->totalCopies >= $this->minCopies && !$resolver->reachedMinLimit()) {
+
+			$this->form->setSubmittedBy($this->removeButton->create($this));
+
 			$this->resetFormEvents();
 
 			$this->onRemoveEvent();


### PR DESCRIPTION
Although setValidationScope([]) in RemoveButton class, removing fields keeps validating.

This because the button is removed from httpData and form is submitted by no button (setSubmittedBy is "true").

Create a dummy remove button just to make validationscope work.