### PR TITLE
Fixed Argument 2 passed to Contributte\FormMultiplier\ComponentResolver::__construct() must be of the type array, object given

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -275,7 +275,7 @@ class Multiplier extends Container
 			$count = $resolver->getCreateNum();
 			while ($count > 0 && $this->isValidMaxCopies()) {
 				$this->noValidate[] = $containers[] = $container = $this->addCopy();
-				$container->setValues($this->createContainer()->getValues());
+				$container->setValues($this->createContainer()->getValues('array'));
 				$count--;
 			}
 		}

--- a/tests/unit/MultiplierTest.php
+++ b/tests/unit/MultiplierTest.php
@@ -221,6 +221,7 @@ class MultiplierTest extends \Codeception\TestCase\Test
 					],
 				],
 				['bar' => 'bar'],
+				Multiplier::SUBMIT_CREATE_NAME => '',
 			],
 		]);
 
@@ -239,6 +240,10 @@ class MultiplierTest extends \Codeception\TestCase\Test
 				],
 				[
 					'bar' => 'bar',
+					'm2' => [],
+				],
+				[
+					'bar' => '',
 					'm2' => [],
 				],
 			],


### PR DESCRIPTION
Fixed Argument 2 passed to Contributte\FormMultiplier\ComponentResolver::__construct() must be of the type array, object given