### PR TITLE
Fixes for nested multipliers

### DIFF
--- a/src/ComponentResolver.php
+++ b/src/ComponentResolver.php
@@ -39,7 +39,7 @@ final class ComponentResolver
 				$this->createAction = true;
 				$num = substr($index, 18);
 				if ($num) {
-					$this->createNum = (int)$num;
+					$this->createNum = (int) $num;
 				}
 
 				return;

--- a/src/ComponentResolver.php
+++ b/src/ComponentResolver.php
@@ -21,22 +21,17 @@ final class ComponentResolver
 	/** @var mixed[] */
 	private ?array $purgedHttpData = null;
 
-	/** @var mixed[] */
-	private array $defaults = [];
-
 	private int $minCopies;
 
 	private bool $reached = false;
 
 	/**
 	 * @param mixed[] $httpData
-	 * @param mixed[] $defaults
 	 */
-	public function __construct(array $httpData, array $defaults, ?int $maxCopies, int $minCopies)
+	public function __construct(array $httpData, ?int $maxCopies, int $minCopies)
 	{
 		$this->httpData = $httpData;
 		$this->maxCopies = $maxCopies;
-		$this->defaults = $defaults;
 		$this->minCopies = $minCopies;
 
 		foreach ($httpData as $index => $_) {
@@ -61,7 +56,7 @@ final class ComponentResolver
 		}
 	}
 
-	public function getCreateNum(): int
+	public function getCreateNum() : int
 	{
 		return $this->createNum;
 	}
@@ -69,15 +64,15 @@ final class ComponentResolver
 	/**
 	 * @return mixed[]
 	 */
-	public function getDefaults(): array
+	public function getDefaults() : array
 	{
-		return array_slice($this->defaults, 0, $this->maxCopies, true);
+		return $this->getValues();
 	}
 
 	/**
 	 * @return mixed[]
 	 */
-	public function getValues(): array
+	public function getValues() : array
 	{
 		return array_slice($this->getPurgedHttpData(), 0, $this->maxCopies, true);
 	}
@@ -85,7 +80,7 @@ final class ComponentResolver
 	/**
 	 * @return mixed[]
 	 */
-	public function getPurgedHttpData(): array
+	public function getPurgedHttpData() : array
 	{
 		if ($this->purgedHttpData === null) {
 			$httpData = $this->httpData;
@@ -112,12 +107,12 @@ final class ComponentResolver
 		return $this->purgedHttpData;
 	}
 
-	public function isCreateAction(): bool
+	public function isCreateAction() : bool
 	{
 		return $this->createAction;
 	}
 
-	public function isRemoveAction(): bool
+	public function isRemoveAction() : bool
 	{
 		return $this->removeAction;
 	}
@@ -127,7 +122,7 @@ final class ComponentResolver
 		return $this->removeId;
 	}
 
-	public function reachedMinLimit(): bool
+	public function reachedMinLimit() : bool
 	{
 		return $this->reached;
 	}

--- a/src/ComponentResolver.php
+++ b/src/ComponentResolver.php
@@ -39,7 +39,7 @@ final class ComponentResolver
 				$this->createAction = true;
 				$num = substr($index, 18);
 				if ($num) {
-					$this->createNum = (int) $num;
+					$this->createNum = (int)$num;
 				}
 
 				return;
@@ -56,7 +56,7 @@ final class ComponentResolver
 		}
 	}
 
-	public function getCreateNum() : int
+	public function getCreateNum(): int
 	{
 		return $this->createNum;
 	}
@@ -64,15 +64,15 @@ final class ComponentResolver
 	/**
 	 * @return mixed[]
 	 */
-	public function getDefaults() : array
+	public function getDefaults(): array
 	{
-		return $this->getValues();
+		return array_slice([], 0, $this->maxCopies, true);
 	}
 
 	/**
 	 * @return mixed[]
 	 */
-	public function getValues() : array
+	public function getValues(): array
 	{
 		return array_slice($this->getPurgedHttpData(), 0, $this->maxCopies, true);
 	}
@@ -80,7 +80,7 @@ final class ComponentResolver
 	/**
 	 * @return mixed[]
 	 */
-	public function getPurgedHttpData() : array
+	public function getPurgedHttpData(): array
 	{
 		if ($this->purgedHttpData === null) {
 			$httpData = $this->httpData;
@@ -107,12 +107,12 @@ final class ComponentResolver
 		return $this->purgedHttpData;
 	}
 
-	public function isCreateAction() : bool
+	public function isCreateAction(): bool
 	{
 		return $this->createAction;
 	}
 
-	public function isRemoveAction() : bool
+	public function isRemoveAction(): bool
 	{
 		return $this->removeAction;
 	}
@@ -122,7 +122,7 @@ final class ComponentResolver
 		return $this->removeId;
 	}
 
-	public function reachedMinLimit() : bool
+	public function reachedMinLimit(): bool
 	{
 		return $this->reached;
 	}

--- a/src/Latte/Extension/MultiplierExtension.php
+++ b/src/Latte/Extension/MultiplierExtension.php
@@ -20,6 +20,8 @@ final class MultiplierExtension extends Extension
 			'n:multiplier' => [MultiplierNode::class, 'create'],
 			'multiplier:remove' => [MultiplierRemoveNode::class, 'create'],
 			'multiplier:add' => [MultiplierAddNode::class, 'create'],
+			'btnRemove' => [MultiplierRemoveNode::class, 'create'],
+			'btnCreate' => [MultiplierAddNode::class, 'create'],
 		];
 	}
 

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -211,6 +211,35 @@ class Multiplier extends Container
 		return $container;
 	}
 
+    public function createCopies(): void
+    {
+        if ($this->created === true) {
+            return;
+        }
+        $this->created = true;
+
+        $resolver = new ComponentResolver($this->httpData, $this->values, $this->maxCopies, $this->minCopies);
+
+        $this->attachCreateButtons();
+        $this->createComponents($resolver);
+        $this->detachCreateButtons();
+
+        if ($this->maxCopies === null || $this->totalCopies < $this->maxCopies) {
+            $this->attachCreateButtons();
+        }
+
+        if ($resolver->isRemoveAction() && $this->totalCopies >= $this->minCopies && !$resolver->reachedMinLimit()) {
+            $this->form->setSubmittedBy($this->removeButton->create($this));
+
+            $this->resetFormEvents();
+
+            $this->onRemoveEvent();
+        }
+
+        // onCreateEvent
+        $this->onCreateEvent();
+    }
+
 	public function createCopies(): void
 	{
 		if ($this->created === true) {
@@ -464,9 +493,9 @@ class Multiplier extends Container
 		}
 
 		// Default number of copies
-		if (!$this->isFormSubmitted() && !$this->values) {
+		if (!$this->values) {
 			$copyNumber = $this->copyNumber;
-			while ($copyNumber > 0 && $this->isValidMaxCopies()) {
+			while ($copyNumber > 0 && $this->isValidMaxCopies() && $this->totalCopies < $this->minCopies) {
 				$containers[] = $container = $this->addCopy();
 				$copyNumber--;
 			}

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -450,14 +450,14 @@ class Multiplier extends Container
 		$this->removeComponent($component);
 	}
 
-    private function createComponents(ComponentResolver $resolver): void
+    private function createComponents(bool $forceValues = false) : void
     {
         $containers = [];
         $containerDefaults = $this->createContainer()->getValues('array');
 
         // Components from httpData
-        if ($this->isFormSubmitted()) {
-            foreach ($resolver->getValues() as $number => $_) {
+        if ($this->isFormSubmitted() && !$forceValues) {
+            foreach ($this->resolver->getValues() as $number => $_) {
                 $containers[] = $container = $this->addCopy($number);
 
                 /** @var BaseControl $control */

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -476,6 +476,7 @@ class Multiplier extends Container
     private function createComponents(ComponentResolver $resolver): void
     {
         $containers = [];
+        $containerDefaults = $this->createContainer()->getValues('array');
 
         // Components from httpData
         if ($this->isFormSubmitted()) {
@@ -483,7 +484,7 @@ class Multiplier extends Container
                 $containers[] = $container = $this->addCopy($number);
 
                 /** @var BaseControl $control */
-                foreach ($container->getControls() as $control) {
+                foreach ($container->getComponents(false, IControl::class) as $control) {
                     $control->loadHttpData();
                 }
             }
@@ -500,6 +501,7 @@ class Multiplier extends Container
             $copyNumber = $this->copyNumber;
             while ($copyNumber > 0 && $this->isValidMaxCopies() && $this->totalCopies < $this->minCopies) {
                 $containers[] = $container = $this->addCopy();
+                $container->setValues($containerDefaults);
                 $copyNumber--;
             }
         }
@@ -514,7 +516,7 @@ class Multiplier extends Container
             $count = $resolver->getCreateNum();
             while ($count > 0 && $this->isValidMaxCopies()) {
                 $this->noValidate[] = $containers[] = $container = $this->addCopy();
-                $container->setValues($this->createContainer()->getValues('array'));
+                $container->setValues($containerDefaults);
                 $count--;
             }
         }

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -358,6 +358,7 @@ class Multiplier extends Container
 		if ($this->created) {
 			foreach ($this->getContainers() as $container) {
 				$this->removeComponent($container);
+				$this->totalCopies--;
 			}
 
 			$this->created = false;
@@ -472,56 +473,58 @@ class Multiplier extends Container
 		$this->removeComponent($component);
 	}
 
-	private function createComponents(ComponentResolver $resolver): void
-	{
-		$containers = [];
+    private function createComponents(ComponentResolver $resolver): void
+    {
+        $containers = [];
 
-		// Components from httpData
-		if ($this->isFormSubmitted()) {
-			foreach ($resolver->getValues() as $number => $_) {
-				$containers[] = $container = $this->addCopy($number);
+        // Components from httpData
+        if ($this->isFormSubmitted()) {
+            foreach ($resolver->getValues() as $number => $_) {
+                $containers[] = $container = $this->addCopy($number);
 
-				/** @var BaseControl $control */
-				foreach ($container->getControls() as $control) {
-					$control->loadHttpData();
-				}
-			}
-		} else { // Components from default values
-			foreach ($resolver->getDefaults() as $number => $values) {
-				$containers[] = $this->addCopy($number, $values);
-			}
-		}
+                /** @var BaseControl $control */
+                foreach ($container->getControls() as $control) {
+                    $control->loadHttpData();
+                }
+            }
 
-		// Default number of copies
-		if (!$this->values) {
-			$copyNumber = $this->copyNumber;
-			while ($copyNumber > 0 && $this->isValidMaxCopies() && $this->totalCopies < $this->minCopies) {
-				$containers[] = $container = $this->addCopy();
-				$copyNumber--;
-			}
-		}
+        } else { // Components from default values
+            foreach ($resolver->getDefaults() as $number => $values) {
+                $containers[] = $this->addCopy($number, $values);
+            }
 
-		// Dynamic
-		foreach ($this->onCreateComponents as $callback) {
-			$callback($this);
-		}
+        }
 
-		// New containers, if create button hitted
-		if ($this->form !== null && $resolver->isCreateAction() && $this->form->isValid()) {
-			$count = $resolver->getCreateNum();
-			while ($count > 0 && $this->isValidMaxCopies()) {
-				$this->noValidate[] = $containers[] = $container = $this->addCopy();
-				$container->setValues($this->createContainer()->getValues('array'));
-				$count--;
-			}
-		}
+        // Default number of copies
+        if (!$this->values) {
+            $copyNumber = $this->copyNumber;
+            while ($copyNumber > 0 && $this->isValidMaxCopies() && $this->totalCopies < $this->minCopies) {
+                $containers[] = $container = $this->addCopy();
+                $copyNumber--;
+            }
+        }
 
-		if ($this->removeButton && $this->totalCopies <= $this->minCopies) {
-			foreach ($containers as $container) {
-				$this->detachRemoveButton($container);
-			}
-		}
-	}
+        // Dynamic
+        foreach ($this->onCreateComponents as $callback) {
+            $callback($this);
+        }
+
+        // New containers, if create button hitted
+        if ($resolver->isCreateAction() && $this->form->isValid()) {
+            $count = $resolver->getCreateNum();
+            while ($count > 0 && $this->isValidMaxCopies()) {
+                $this->noValidate[] = $containers[] = $container = $this->addCopy();
+                $container->setValues($this->createContainer()->getValues('array'));
+                $count--;
+            }
+        }
+
+        if ($this->removeButton && $this->totalCopies <= $this->minCopies) {
+            foreach ($containers as $container) {
+                $this->detachRemoveButton($container);
+            }
+        }
+    }
 
 	private function detachCreateButtons(): void
 	{

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -75,7 +75,7 @@ class Multiplier extends Container
 		$this->minCopies = $this->copyNumber = $copyNumber;
 		$this->maxCopies = $maxCopies;
 
-		$this->monitor(Form::class, function (Form $form): void {
+		$this->monitor(Form::class, function (Form $form) : void {
 			$this->form = $form;
 
 			if ($this->getCurrentGroup() === null) {
@@ -125,31 +125,31 @@ class Multiplier extends Container
 		return $this;
 	}
 
-	public function setMinCopies(int $minCopies): self
+	public function setMinCopies(int $minCopies) : self
 	{
 		$this->minCopies = $minCopies;
 
 		return $this;
 	}
 
-	public function setFactory(callable $factory): self
+	public function setFactory(callable $factory) : self
 	{
 		$this->factory = $factory;
 
 		return $this;
 	}
 
-	public function getMaxCopies(): ?int
+	public function getMaxCopies() : ?int
 	{
 		return $this->maxCopies;
 	}
 
-	public function getMinCopies(): ?int
+	public function getMinCopies() : ?int
 	{
 		return $this->minCopies;
 	}
 
-	public function getCopyNumber(): int
+	public function getCopyNumber() : int
 	{
 		return $this->copyNumber;
 	}
@@ -159,7 +159,7 @@ class Multiplier extends Container
 		return $this->removeButton = new RemoveButton($caption);
 	}
 
-	public function addCreateButton(?string $caption = null, int $copyCount = 1): CreateButton
+	public function addCreateButton(?string $caption = null, int $copyCount = 1) : CreateButton
 	{
 		return $this->createButtons[$copyCount] = new CreateButton($caption, $copyCount);
 	}
@@ -167,7 +167,7 @@ class Multiplier extends Container
 	/**
 	 * @param Control[]|null $controls
 	 */
-	public function validate(?array $controls = null): void
+	public function validate(?array $controls = null) : void
 	{
 		/** @var Control[] $components */
 		$components = $controls ?? iterator_to_array($this->getComponents());

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -218,9 +218,9 @@ class Multiplier extends Container
         }
         $this->created = true;
 
-        if (!isset($this->resolver)) {
-            $this->resolver = new ComponentResolver($this->values, $this->maxCopies, $this->minCopies);
-        }
+		if (!isset($this->resolver)) {
+			$this->resolver = new ComponentResolver($this->values, $this->maxCopies, $this->minCopies);
+		}
 
         $this->attachCreateButtons();
         $this->createComponents($forceValues);

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -66,8 +66,8 @@ class Multiplier extends Container
 
 	private bool $attachedCalled = false;
 
-	/** @var ComponentResolver|null */
-	protected $resolver = null;
+	/** @var ComponentResolver */
+	protected $resolver;
 
 	public function __construct(callable $factory, int $copyNumber = 1, ?int $maxCopies = null)
 	{

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -467,8 +467,10 @@ class Multiplier extends Container
             }
 
         } else { // Components from default values
-            foreach ($resolver->getDefaults() as $number => $values) {
-                $containers[] = $this->addCopy($number, $values);
+            foreach ($this->resolver->getValues() as $number => $values) {
+                $containers[] = $container = $this->addCopy($number);
+                $container->setValues($containerDefaults);
+                $container->setValues($values);
             }
 
         }

--- a/tests/unit/CreateButtonTest.php
+++ b/tests/unit/CreateButtonTest.php
@@ -89,7 +89,11 @@ class CreateButtonTest extends \Codeception\TestCase\Test
 				$submitter->setHtmlAttribute('class', 'add-btn');
 			});
 
-		$response = $this->services->form->createRequest($factory->createForm())->setPost([
+		$response = $this->services->form->createRequest($factory
+			->formModifier(function (\Nette\Application\UI\Form $form) {
+				$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
+				};
+			})->createForm())->setPost([
 			'm' => [
 				['bar' => ''],
 				['bar' => ''],

--- a/tests/unit/LatteTest.php
+++ b/tests/unit/LatteTest.php
@@ -36,8 +36,8 @@ class LatteTest extends \Codeception\TestCase\Test
 		$presenter['m'] = $form;
 
 		$string = $this->latte->renderToString(__DIR__ . '/templates/macros.latte', ['form' => $form]);
-		$this->assertRegExp('#name="m\[multiplier_creator]"#', $string);
-		$this->assertRegExp('#name="m\[multiplier_creator2]"#', $string);
+		$this->assertMatchesRegularExpression('#name="m\[multiplier_creator]"#', $string);
+		$this->assertMatchesRegularExpression('#name="m\[multiplier_creator2]"#', $string);
 	}
 
 }

--- a/tests/unit/MultiplierTest.php
+++ b/tests/unit/MultiplierTest.php
@@ -44,6 +44,10 @@ class MultiplierTest extends \Codeception\TestCase\Test
 						$this->parameters['onCreate'][] = $container;
 					};
 				})
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
+					};
+				})
 				->createForm()
 		)
 			->setPost($params = [
@@ -91,6 +95,10 @@ class MultiplierTest extends \Codeception\TestCase\Test
 				->multiplierModifier(function (Multiplier $multiplier) {
 					$multiplier->onCreate[] = function (Container $container) {
 						$this->parameters['onCreate'][] = $container;
+					};
+				})
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
 					};
 				})
 				->createForm()
@@ -141,6 +149,10 @@ class MultiplierTest extends \Codeception\TestCase\Test
 				->multiplierModifier(function (Multiplier $multiplier) {
 					$multiplier->onCreate[] = function (Container $container) {
 						$this->parameters['onCreate'][] = $container;
+					};
+				})
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
 					};
 				})
 				->createForm()
@@ -209,6 +221,10 @@ class MultiplierTest extends \Codeception\TestCase\Test
 					}));
 					$container['m2']->addCreateButton('create');
 				})
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
+					};
+				})
 				->createForm()
 		);
 		$request->setPost([
@@ -239,11 +255,15 @@ class MultiplierTest extends \Codeception\TestCase\Test
 				],
 				[
 					'bar' => 'bar',
-					'm2' => [],
+					'm2' => [
+						['bar2' => ''],
+					],
 				],
 				[
 					'bar' => '',
-					'm2' => [],
+					'm2' => [
+						['bar2' => ''],
+					],
 				],
 			],
 		], $send->getValues());
@@ -299,14 +319,15 @@ class MultiplierTest extends \Codeception\TestCase\Test
 			->multiplierModifier(function (Multiplier $multiplier) {
 				$multiplier->onCreate[] = function (Container $container) {
 					$this->parameters['onCreate'][] = $container;
+					$container->setParent(null, 'X');
+					//var_dump($container);
 				};
 				$multiplier->addCreateButton();
 				$multiplier->addRemoveButton();
-				$multiplier->setMinCopies(1);
+				//$multiplier->setMinCopies(1);
 			})
 			->createForm());
 		$dom = $request->render(__DIR__ . '/templates/group.latte')->toDomQuery();
-
 		$this->assertDomHas($dom, 'input[name="m[0][multiplier_remover]"]');
 		$this->assertDomHas($dom, 'input[name="m[1][multiplier_remover]"]');
 	}
@@ -375,6 +396,10 @@ class MultiplierTest extends \Codeception\TestCase\Test
 						->setPrompt('Select');
 				})
 				->addCreateButton()
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
+					};
+				})
 				->createForm()
 		)
 			->setPost($params = [

--- a/tests/unit/RemoveButtonTest.php
+++ b/tests/unit/RemoveButtonTest.php
@@ -188,6 +188,10 @@ class RemoveButtonTest extends \Codeception\TestCase\Test
 					$submitter->setHtmlAttribute('class', 'btn btn-remove');
 				})
 				->addCreateButton()
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
+					};
+				})
 				->createForm()
 		)->setPost([
 			'm' => [
@@ -210,6 +214,10 @@ class RemoveButtonTest extends \Codeception\TestCase\Test
 				->setMinCopies(0)
 				->addRemoveButton()
 				->addCreateButton()
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
+					};
+				})
 				->createForm()
 		)->modifyForm(function (Form $form) {
 			$form['m']->setValues([
@@ -237,6 +245,10 @@ class RemoveButtonTest extends \Codeception\TestCase\Test
 				->multiplierModifier(function (Multiplier $multiplier) use (&$called) {
 					$multiplier->onRemove[] = function () use (&$called) {
 						$called = true;
+					};
+				})
+				->formModifier(function (Form $form) {
+					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
 					};
 				})
 				->createForm()


### PR DESCRIPTION
Hello, there is a problem with nested multipliers, if the top-one has minCopies=0 and the nested one has minCopies>0. Then it will not create any copies, because form has been submitted (condition on line 260). With this, there is also a bug - when removing copies, counter is not decreased.

With this two changes, nested multipliers with minimum copies does work.