### PR TITLE
Fix get attributes from latte 3 multiplier:add tag.

### DIFF
--- a/src/Latte/Extension/Node/MultiplierAddNode.php
+++ b/src/Latte/Extension/Node/MultiplierAddNode.php
@@ -35,6 +35,8 @@ final class MultiplierAddNode extends StatementNode
 			$node->part = new StringNode('1');
 		}
 
+		$tag->parser->stream->tryConsume(',');
+
 		$node->attributes = $tag->parser->parseArguments();
 
 		return $node;


### PR DESCRIPTION
Hi,

I found a problem that my macros for latte 3 didn't work with attributes. Parser can't take it. 
![image](https://github.com/contributte/forms-multiplier/assets/3205711/9cada9c2-ab27-4713-91cb-005fdbb53f19)

So I added a part to the parameter retrieval that handles this comma, and then it parses the arguments correctly.