### PR TITLE
FIX compile error

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -323,7 +323,7 @@ class Multiplier extends Container
 	 * @param mixed[]|object $values
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 	 */
-	public function setValues($values, bool $erase = false): self
+	public function setValues($values, bool $erase = false): static
 	{
 		$values = $values instanceof Traversable ? iterator_to_array($values) : (array) $values;
 


### PR DESCRIPTION
PHP 8.2 
Declaration of Contributte\FormMultiplier\Multiplier::setValues($values, bool $erase = false): Contributte\FormMultiplier\Multiplier must be compatible with Nette\Forms\Container::setValues(object|array $data, bool $erase = false): static