### PR TITLE
Fix tests with nette/component-model 3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "webchemistry/testing-helpers": "~2.0.0"
   },
   "conflict": {
-    "latte/latte": "<3.0.0"
+    "latte/latte": "<3.0.0",
+    "nette/component-model": "<3.1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -170,7 +170,7 @@ class Multiplier extends Container
 	public function validate(?array $controls = null): void
 	{
 		/** @var Control[] $components */
-		$components = $controls ?? iterator_to_array($this->getComponents());
+		$components = $controls ?? $this->getComponents();
 
 		foreach ($components as $index => $control) {
 			foreach ($this->noValidate as $item) {
@@ -307,14 +307,14 @@ class Multiplier extends Container
 	}
 
 	/**
-	 * @return Iterator<int|string,Container>
+	 * @return array<int|string,Container>
 	 */
-	public function getContainers(): Iterator
+	public function getContainers(): iterable
 	{
 		$this->createCopies();
 
-		/** @var Iterator<int|string,Container> $containers */
-		$containers = $this->getComponents(false, Container::class);
+		/** @var array<int|string,Container> $containers */
+		$containers = array_filter($this->getComponents(), fn ($component) => $component instanceof Container);
 
 		return $containers;
 	}
@@ -393,7 +393,7 @@ class Multiplier extends Container
 
 	protected function createNumber(): int
 	{
-		$count = iterator_count($this->getComponents(false, Form::class));
+		$count = count(array_filter($this->getComponents(), fn ($component) => $component instanceof Form));
 		while ($this->getComponent((string) $count, false)) {
 			$count++;
 		}
@@ -428,7 +428,7 @@ class Multiplier extends Container
 	 */
 	protected function getFirstSubmit(): ?string
 	{
-		$submits = iterator_to_array($this->getComponents(false, SubmitButton::class));
+		$submits = array_filter($this->getComponents(), fn ($component) => $component instanceof SubmitButton);
 		if ($submits) {
 			return reset($submits)->getName();
 		}


### PR DESCRIPTION

`Container::getComponents()` returns array when `$deep` is false:
https://github.com/nette/component-model/commit/7f613eed7f5e57b6bde2d0be1bfdbb7e161620b3
