### PR TITLE
Revert unneeded changes from "Fixes for nested multipliers (#59)"

### DIFF
--- a/src/Latte/Extension/MultiplierExtension.php
+++ b/src/Latte/Extension/MultiplierExtension.php
@@ -20,8 +20,6 @@ final class MultiplierExtension extends Extension
 			'n:multiplier' => [MultiplierNode::class, 'create'],
 			'multiplier:remove' => [MultiplierRemoveNode::class, 'create'],
 			'multiplier:add' => [MultiplierAddNode::class, 'create'],
-			'btnRemove' => [MultiplierRemoveNode::class, 'create'],
-			'btnCreate' => [MultiplierAddNode::class, 'create'],
 		];
 	}
 

--- a/tests/Unit/CreateButtonTest.php
+++ b/tests/Unit/CreateButtonTest.php
@@ -94,11 +94,7 @@ class CreateButtonTest extends UnitTest
 				$submitter->setHtmlAttribute('class', 'add-btn');
 			});
 
-		$response = $this->services->form->createRequest($factory
-			->formModifier(function (\Nette\Application\UI\Form $form) {
-				$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
-				};
-			})->createForm())->setPost([
+		$response = $this->services->form->createRequest($factory->createForm())->setPost([
 			'm' => [
 				['bar' => ''],
 				['bar' => ''],

--- a/tests/Unit/MultiplierTest.php
+++ b/tests/Unit/MultiplierTest.php
@@ -49,10 +49,6 @@ class MultiplierTest extends UnitTest
 						$this->parameters['onCreate'][] = $container;
 					};
 				})
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
-					};
-				})
 				->createForm()
 		)
 			->setPost($params = [
@@ -100,10 +96,6 @@ class MultiplierTest extends UnitTest
 				->multiplierModifier(function (Multiplier $multiplier) {
 					$multiplier->onCreate[] = function (Container $container) {
 						$this->parameters['onCreate'][] = $container;
-					};
-				})
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
 					};
 				})
 				->createForm()
@@ -154,10 +146,6 @@ class MultiplierTest extends UnitTest
 				->multiplierModifier(function (Multiplier $multiplier) {
 					$multiplier->onCreate[] = function (Container $container) {
 						$this->parameters['onCreate'][] = $container;
-					};
-				})
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
 					};
 				})
 				->createForm()
@@ -225,10 +213,6 @@ class MultiplierTest extends UnitTest
 						$container->addText('bar2');
 					}));
 					$container['m2']->addCreateButton('create');
-				})
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
-					};
 				})
 				->createForm()
 		);
@@ -396,15 +380,14 @@ class MultiplierTest extends UnitTest
 			->multiplierModifier(function (Multiplier $multiplier) {
 				$multiplier->onCreate[] = function (Container $container) {
 					$this->parameters['onCreate'][] = $container;
-					$container->setParent(null, 'X');
-					//var_dump($container);
 				};
 				$multiplier->addCreateButton();
 				$multiplier->addRemoveButton();
-				//$multiplier->setMinCopies(1);
+				$multiplier->setMinCopies(1);
 			})
 			->createForm());
 		$dom = $request->render(__DIR__ . '/templates/group.latte')->toDomQuery();
+
 		$this->assertDomHas($dom, 'input[name="m[0][multiplier_remover]"]');
 		$this->assertDomHas($dom, 'input[name="m[1][multiplier_remover]"]');
 	}
@@ -473,10 +456,6 @@ class MultiplierTest extends UnitTest
 						->setPrompt('Select');
 				})
 				->addCreateButton()
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
-					};
-				})
 				->createForm()
 		)
 			->setPost($params = [

--- a/tests/Unit/RemoveButtonTest.php
+++ b/tests/Unit/RemoveButtonTest.php
@@ -193,10 +193,6 @@ class RemoveButtonTest extends UnitTest
 					$submitter->setHtmlAttribute('class', 'btn btn-remove');
 				})
 				->addCreateButton()
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
-					};
-				})
 				->createForm()
 		)->setPost([
 			'm' => [
@@ -219,10 +215,6 @@ class RemoveButtonTest extends UnitTest
 				->setMinCopies(0)
 				->addRemoveButton()
 				->addCreateButton()
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
-					};
-				})
 				->createForm()
 		)->modifyForm(function (Form $form) {
 			$form['m']->setValues([
@@ -250,10 +242,6 @@ class RemoveButtonTest extends UnitTest
 				->multiplierModifier(function (Multiplier $multiplier) use (&$called) {
 					$multiplier->onRemove[] = function () use (&$called) {
 						$called = true;
-					};
-				})
-				->formModifier(function (Form $form) {
-					$form->onSuccess[] = $form->onError[] = $form->onSubmit[] = function () {
 					};
 				})
 				->createForm()


### PR DESCRIPTION
This partially reverts commit 39725d333355b2a1ef21dac3948909cf1e5d4744, only keeping the part relevant for nested support and a PHPUnit deprecation fix.

The commit introduced a regression in `testGroupManualRenderWithButtons` so this will minimize the changes that could affect it.

- Latte 2 macros are trivial to migrate and unclearly named, no need to keep them for BC.
- The onSuccess handlers were already fixed in ed96ba0276a2db878841836c403f60568c7a3a98.
- `testGroupManualRenderWithButtons` look like remnants of debugging effort, they do not fix the test.

For reference, the reverted change is the following commit that was squashed into 39725d333355b2a1ef21dac3948909cf1e5d4744, except for the change to `testSendNested`: https://github.com/contributte/forms-multiplier/pull/59/commits/2c33de22b8343ba08210764711e4776a5bf58227
