### PR TITLE
Multiplier: Add missing param typehint to getValues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=8.0",
-    "nette/forms": "^3.1.0"
+    "nette/forms": "^3.1.12"
   },
   "require-dev": {
     "codeception/codeception": "^4.1.9",

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -277,9 +277,9 @@ class Multiplier extends Container
 	}
 
 	/**
+	 * @param  string|object|bool|null  $returnType  'array' for array
 	 * @param  Control[]|null  $controls
 	 * @return object|mixed[]
-	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint
 	 */
 	public function getValues($returnType = null, ?array $controls = null): object|array
 	{
@@ -288,12 +288,15 @@ class Multiplier extends Container
 		}
 
 		/** @var mixed[] $values */
-		$values = parent::getValues('array', $controls);
+		$values = parent::getValues(self::Array, $controls);
 		$values = array_values($values);
 
-		$returnType = $returnType === true ? 'array' : $returnType; // @phpstan-ignore-line nette backwards compatibility
+		if ($returnType === true) {
+			trigger_error(static::class . '::' . __FUNCTION__ . "(true) is deprecated, use getValues('array').", E_USER_DEPRECATED);
+			$returnType = self::Array;
+		}
 
-		return $returnType === 'array' ? $values : ArrayHash::from($values);
+		return $returnType === self::Array ? $values : ArrayHash::from($values);
 	}
 
 	/**
@@ -453,7 +456,7 @@ class Multiplier extends Container
 	private function createComponents(bool $forceValues = false): void
 	{
 		$containers = [];
-		$containerDefaults = $this->createContainer()->getValues('array');
+		$containerDefaults = $this->createContainer()->getValues(self::Array);
 
 		// Components from httpData
 		if ($this->isFormSubmitted() && !$forceValues) {


### PR DESCRIPTION
This fixes the following PHPStan errors:

  280    Method Contributte\FormMultiplier\Multiplier::getValues() has parameter $returnType with no type specified.
  290    No error to ignore is reported on line 290.

Let’s also deprecate passing bool `$returnType` deprecated like `nette/forms` 3.2.0 does:

https://github.com/nette/forms/commit/0a812bd6e70aba54c6e563aef4d77bd4388607ae

Also use Array constant made public in 3.1.12:

https://github.com/nette/forms/commit/0be7b3d5971113515e9020cf53453e74f02a46a1
