### PR TITLE
ci: Apply patch to work around nette/application 3.2 breaking tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ phpstan:
 	vendor/bin/phpstan analyse -c phpstan.neon
 
 tests:
+	# Fix compatibility with https://github.com/nette/application/commit/bb8f93c60f9e747530431eef75df8b0aa8ab9d5b
+	-patch -p1 -N -d vendor/webchemistry/testing-helpers < tests/webchemistry-testing-helpers-nette-3.2.patch
 	vendor/bin/codecept run
 
 coverage:
+	# Fix compatibility with https://github.com/nette/application/commit/bb8f93c60f9e747530431eef75df8b0aa8ab9d5b
+	-patch -p1 -N -d vendor/webchemistry/testing-helpers < tests/webchemistry-testing-helpers-nette-3.2.patch
 ifdef GITHUB_ACTION
 	phpdbg -qrr vendor/bin/codecept run --coverage-xml
 else

--- a/tests/webchemistry-testing-helpers-nette-3.2.patch
+++ b/tests/webchemistry-testing-helpers-nette-3.2.patch
@@ -1,0 +1,11 @@
+--- a/src/Components/Presenter.php
++++ b/src/Components/Presenter.php
+@@ -31,7 +31,7 @@ class Presenter {
+
+ 			$request = new Request(new UrlScript('http://localhost/'));
+ 			$presenter->injectPrimary(
+-				null, null, new RouterStub(), $request, new Response(), null,
++				$request, new Response(), null, new RouterStub(), null,
+ 				null, $this->createTemplateFactory($request)
+ 			);
+ 		}


### PR DESCRIPTION
There is still breakage from https://github.com/nette/application/commit/bb8f93c60f9e747530431eef75df8b0aa8ab9d5b in `webchemistry/testing-helpers`. It can be fixed with this patch but there are other issues with it and the [repo looks dead](https://github.com/WebChemistry/testing-helpers) so not sure if it makes sense trying to track them down.
