### PR TITLE
[v4] FIX compile error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
     "webchemistry/testing-helpers": "^4.0.0"
   },
   "conflict": {
-    "latte/latte": "<3.0.0",
-    "nette/component-model": "<3.1.0"
+    "latte/latte": "<3.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "webchemistry/testing-helpers": "^4.0.0"
   },
   "conflict": {
-    "latte/latte": "<3.0.0"
+    "latte/latte": "<3.0.0",
+    "nette/component-model": "<3.1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "latte/latte": "^3.0.0",
     "contributte/qa": "^0.3",
     "contributte/phpstan": "^0.1",
-    "webchemistry/testing-helpers": "~2.0.0"
+    "webchemistry/testing-helpers": "^4.0.0"
   },
   "conflict": {
     "latte/latte": "<3.0.0"

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -169,7 +169,7 @@ class Multiplier extends Container
 	public function validate(?array $controls = null): void
 	{
 		/** @var Control[] $components */
-		$components = $controls ?? iterator_to_array($this->getComponents());
+		$components = $controls ?? $this->getComponents();
 
 		foreach ($components as $index => $control) {
 			foreach ($this->noValidate as $item) {
@@ -302,14 +302,14 @@ class Multiplier extends Container
 	}
 
 	/**
-	 * @return Iterator<int|string,Container>
+	 * @return array<int|string,Container>
 	 */
-	public function getContainers(): Iterator
+	public function getContainers(): iterable
 	{
 		$this->createCopies();
 
-		/** @var Iterator<int|string,Container> $containers */
-		$containers = $this->getComponents(false, Container::class);
+		/** @var array<int|string,Container> $containers */
+		$containers = array_filter($this->getComponents(), fn ($component) => $component instanceof Container);
 
 		return $containers;
 	}
@@ -385,7 +385,7 @@ class Multiplier extends Container
 
 	protected function createNumber(): int
 	{
-		$count = iterator_count($this->getComponents(false, Form::class));
+		$count = count(array_filter($this->getComponents(), fn ($component) => $component instanceof Form));
 		while ($this->getComponent((string) $count, false)) {
 			$count++;
 		}
@@ -420,7 +420,7 @@ class Multiplier extends Container
 	 */
 	protected function getFirstSubmit(): ?string
 	{
-		$submits = iterator_to_array($this->getComponents(false, SubmitButton::class));
+		$submits = array_filter($this->getComponents(), fn ($component) => $component instanceof SubmitButton);
 		if ($submits) {
 			return reset($submits)->getName();
 		}

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -318,7 +318,7 @@ class Multiplier extends Container
 	 * @param mixed[]|object $values
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 	 */
-	public function setValues($values, bool $erase = false): self
+	public function setValues($values, bool $erase = false): static
 	{
 		$values = $values instanceof Traversable ? iterator_to_array($values) : (array) $values;
 

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -272,11 +272,11 @@ class Multiplier extends Container
 	}
 
 	/**
+	 * @param  string|object|bool|null  $returnType  'array' for array
 	 * @param  Control[]|null  $controls
 	 * @return object|mixed[]
-	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint
 	 */
-	public function getValues($returnType = null, ?array $controls = null): object|array
+	public function getValues(string|object|bool|null $returnType = null, ?array $controls = null): object|array
 	{
 		if (!$this->resetKeys) {
 			return parent::getValues($returnType, $controls);
@@ -286,7 +286,7 @@ class Multiplier extends Container
 		$values = parent::getValues('array', $controls);
 		$values = array_values($values);
 
-		$returnType = $returnType === true ? 'array' : $returnType; // @phpstan-ignore-line nette backwards compatibility
+		$returnType = $returnType === true ? 'array' : $returnType;
 
 		return $returnType === 'array' ? $values : ArrayHash::from($values);
 	}

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -169,7 +169,7 @@ class Multiplier extends Container
 	public function validate(?array $controls = null): void
 	{
 		/** @var Control[] $components */
-		$components = $controls ?? $this->getComponents();
+		$components = $controls ?? $this->getComponentsArray();
 
 		foreach ($components as $index => $control) {
 			foreach ($this->noValidate as $item) {
@@ -302,16 +302,15 @@ class Multiplier extends Container
 	}
 
 	/**
-	 * @return array<int|string,Container>
+	 * @return Iterator<int|string,Container>
 	 */
-	public function getContainers(): iterable
+	public function getContainers(): Iterator
 	{
 		$this->createCopies();
 
-		/** @var array<int|string,Container> $containers */
-		$containers = array_filter($this->getComponents(), fn ($component) => $component instanceof Container);
+		$containers = array_filter($this->getComponentsArray(), fn ($component) => $component instanceof Container);
 
-		return $containers;
+		return new \ArrayIterator($containers);
 	}
 
 	/**
@@ -385,7 +384,7 @@ class Multiplier extends Container
 
 	protected function createNumber(): int
 	{
-		$count = count(array_filter($this->getComponents(), fn ($component) => $component instanceof Form));
+		$count = count(array_filter($this->getComponentsArray(), fn ($component) => $component instanceof Form));
 		while ($this->getComponent((string) $count, false)) {
 			$count++;
 		}
@@ -420,7 +419,7 @@ class Multiplier extends Container
 	 */
 	protected function getFirstSubmit(): ?string
 	{
-		$submits = array_filter($this->getComponents(), fn ($component) => $component instanceof SubmitButton);
+		$submits = array_filter($this->getComponentsArray(), fn ($component) => $component instanceof SubmitButton);
 		if ($submits) {
 			return reset($submits)->getName();
 		}
@@ -524,6 +523,19 @@ class Multiplier extends Container
 		}
 
 		$container->addComponent($this->removeButton->create($this), self::SUBMIT_REMOVE_NAME);
+	}
+
+	/**
+	 * Wrapper around Container::getComponents() supporting both component-model ≥ 3.1 and < 3.1
+	 *
+	 * @return array<int|string, IComponent>
+	 */
+	private function getComponentsArray(): array
+	{
+		/** @var iterable<IComponent> $components */
+		$components = $this->getComponents();
+
+		return is_array($components) ? $components : iterator_to_array($components);
 	}
 
 }

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -11,6 +11,7 @@ use Nette\Forms\Control;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Controls\SubmitButton;
 use Nette\Forms\Form;
+use Nette\InvalidStateException;
 use Nette\Utils\ArrayHash;
 use Nette\Utils\Arrays;
 use Traversable;
@@ -399,10 +400,11 @@ class Multiplier extends Container
 
 	/**
 	 * @return string[]
+	 * @throws InvalidStateException when not attached.
 	 */
 	protected function getHtmlName(): array
 	{
-		return explode('-', $this->lookupPath(Form::class) ?? '');
+		return explode('-', $this->lookupPath(Form::class));
 	}
 
 	protected function createContainer(): Container


### PR DESCRIPTION
PHP 8.2
Declaration of Contributte\FormMultiplier\Multiplier::setValues($values, bool $erase = false): Contributte\FormMultiplier\Multiplier must be compatible with Nette\Forms\Container::setValues(object|array $data, bool $erase = false): static

(cherry picked from commit 9b4e600be60dfbef5861ecd012b0b57d94837d1a)
