### PR TITLE
Multiplier::validate(): Filter out non-validatable components

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,5 +22,5 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$array of function array_filter expects array, Iterator\<int\|string, Nette\\ComponentModel\\IComponent\> given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 4
 			path: src/Multiplier.php

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -315,7 +315,6 @@ class Multiplier extends Container
 	{
 		$this->createCopies();
 
-		/** @var array<int|string,Container> $containers */
 		$containers = array_filter($this->getComponents(), fn ($component) => $component instanceof Container);
 
 		return $containers;

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -173,8 +173,7 @@ class Multiplier extends Container
 	 */
 	public function validate(?array $controls = null): void
 	{
-		/** @var Control[] $components */
-		$components = $controls ?? $this->getComponents();
+		$components = $controls ?? array_filter($this->getComponents(), fn ($component) => $component instanceof Control || $component instanceof Container);
 
 		foreach ($components as $index => $control) {
 			foreach ($this->noValidate as $item) {


### PR DESCRIPTION
45ed76a7ed22c9b97048441eccd4a7fb2f8f2d6f started filtering components to `Control`s, to appease PHPStan, since `Container::validate()` only accepts `Control[]`. But `Multiplier` does not actually have `Control`s as direct children (other than the ‘Add’ `Submitter`s), so it would stop validating and filtering multiplied controls.

a5a7348fdb1046275e83fa47d73a444695cf21b4 reverted that part but kept the incorrect phpdoc type cast.

Now, it works without the filter because `Container::validate()` already ignores non-validatable components but we should still respect its contract.

Let’s filter the components before passing them down. This will also allow us to drop the lying phpdoc type cast.

Depends on https://github.com/nette/forms/pull/323 for PHPStan to pass.

- [x] Add test reproducing #68 or #79.