### PR TITLE
Fix compatibility with nette/forms 3.2.3

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -324,10 +324,9 @@ class Multiplier extends Container
 	}
 
 	/**
-	 * @param mixed[]|object $values
-	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 * @internal
 	 */
-	public function setValues($values, bool $erase = false): static
+	public function setValues(array|object $values, bool $erase = false, bool $onlyDisabled = false): static
 	{
 		$values = $values instanceof Traversable ? iterator_to_array($values) : (array) $values;
 


### PR DESCRIPTION
https://github.com/nette/forms/commit/e227d87d2ef42f5f9368256dd8719807a16bb49e added an extra argument.

While at it, let’s also narrow the `$values` argument type to match `Container::setValues`.

This change remains compatible with nette/forms 3.2.2.
