### PR TITLE
Bump minimum PHP version to 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,15 +35,9 @@ jobs:
     with:
       php: "8.1"
 
-  test80:
-    name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@master
-    with:
-      php: "8.0"
-
   testlower:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester.yml@master
     with:
-      php: "8.0"
+      php: "8.1"
       composer: "composer update --no-interaction --no-progress --prefer-dist --prefer-stable --prefer-lowest"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ For details on how to use this package, check out our [documentation](.docs).
 
 | State       | Version | Branch   | PHP     |
 |-------------|---------|----------|---------|
-| dev         | `^4.1`  | `master` | `>=8.0` |
-| stable      | `^4.0`  | `master` | `>=8.0` |
+| dev         | `^4.1`  | `master` | `>=8.1` |
+| stable      | `^4.0`  | `v4`     | `>=8.0` |
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "multiplier"
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "nette/forms": "^3.1.12"
   },
   "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ includes:
 
 parameters:
 	level: 8
-	phpVersion: 80000
+	phpVersion: 80100
 
 	scanDirectories:
 		- src


### PR DESCRIPTION
In bde2503bdfb2a59d5bbeb9fcfe536305362bb376, we started to require component-model 3.1.0, which requires PHP 8.1.
As a result, CI can no longer build on PHP 8.0.
Let’s bump the PHP requirement to match.
