### PR TITLE
tests: Check handling actions without button

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -232,11 +232,9 @@ class Multiplier extends Container
 			$this->attachCreateButtons();
 		}
 
-		if ($this->form !== null && $resolver->isRemoveAction() && $this->totalCopies >= $this->minCopies && !$resolver->reachedMinLimit()) {
-			/** @var RemoveButton $removeButton */
-			$removeButton = $this->removeButton;
-			$this->form->setSubmittedBy($removeButton->create($this));
+		if ($this->form !== null && $this->removeButton !== null && $resolver->isRemoveAction() && $this->totalCopies >= $this->minCopies && !$resolver->reachedMinLimit()) {
 
+			$this->form->setSubmittedBy($this->removeButton->create($this));
 			$this->resetFormEvents();
 
 			$this->onRemoveEvent();

--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -234,7 +234,11 @@ class Multiplier extends Container
 
 		if ($this->form !== null && $this->removeButton !== null && $resolver->isRemoveAction() && $this->totalCopies >= $this->minCopies && !$resolver->reachedMinLimit()) {
 
+			// Create dummy remove button. Without this, Nette will validate,
+			// even though the original button has empty validation scope,
+			// since the button has actually been removed.
 			$this->form->setSubmittedBy($this->removeButton->create($this));
+
 			$this->resetFormEvents();
 
 			$this->onRemoveEvent();

--- a/tests/Unit/CreateButtonTest.php
+++ b/tests/Unit/CreateButtonTest.php
@@ -37,6 +37,28 @@ class CreateButtonTest extends UnitTest
 		$this->assertDomHas($dom, 'input[name="m[2][bar]"]');
 	}
 
+	public function testSendCreateWithoutButton()
+	{
+		$this->markTestIncomplete("New containers are added even without a button");
+
+		$response = $this->services->form->createRequest(
+			MultiplierBuilder::create()
+				->createForm()
+		)->setPost([
+			'm' => [
+				['bar' => ''],
+				['bar' => ''],
+				'multiplier_creator' => '',
+			],
+		])->send();
+
+		$dom = $response->toDomQuery();
+
+		$this->assertDomHas($dom, 'input[name="m[0][bar]"]');
+		$this->assertDomHas($dom, 'input[name="m[1][bar]"]');
+		$this->assertDomNotHas($dom, 'input[name="m[2][bar]"]');
+	}
+
 	public function testSendCreateOverMaxCopies()
 	{
 		$response = $this->services->form->createRequest(

--- a/tests/Unit/RemoveButtonTest.php
+++ b/tests/Unit/RemoveButtonTest.php
@@ -107,6 +107,25 @@ class RemoveButtonTest extends UnitTest
 		$this->assertDomNotHas($dom, 'input[name="m[1][bar]"]');
 	}
 
+	public function testSendRemoveWithoutButton()
+	{
+		$response = $this->services->form->createRequest(
+			MultiplierBuilder::create(2)
+				->setMinCopies(1)
+				->addCreateButton()
+				->createForm()
+		)->setPost([
+			'm' => [
+				['bar' => ''],
+				['bar' => '', 'multiplier_remover' => ''],
+			],
+		])->send();
+
+		$dom = $response->toDomQuery();
+		$this->assertDomHas($dom, 'input[name="m[0][bar]"]');
+		$this->assertDomNotHas($dom, 'input[name="m[1][bar]"]');
+	}
+
 	public function testSendRemoveBelowMinCopies()
 	{
 		$response = $this->services->form->createRequest(

--- a/tests/Unit/RemoveButtonTest.php
+++ b/tests/Unit/RemoveButtonTest.php
@@ -107,6 +107,31 @@ class RemoveButtonTest extends UnitTest
 		$this->assertDomNotHas($dom, 'input[name="m[1][bar]"]');
 	}
 
+	/** Regression test for https://github.com/contributte/forms-multiplier/pull/51 */
+	public function testSendRemoveShouldNotValidate()
+	{
+		$response = $this->services->form->createRequest(
+			MultiplierBuilder::create(2)
+				->setMinCopies(1)
+				->beforeFormModifier(function (Form $form) {
+					$form->addInteger('num');
+				})
+				->addRemoveButton()
+				->createForm()
+		)->setPost([
+			'num' => '5+1',
+			'm' => [
+				['bar' => ''],
+				['bar' => '', 'multiplier_remover' => ''],
+			],
+		])->send();
+
+		$dom = $response->toDomQuery();
+		$this->assertFalse($response->hasErrors());
+		$this->assertDomHas($dom, 'input[name="m[0][bar]"]');
+		$this->assertDomNotHas($dom, 'input[name="m[1][bar]"]');
+	}
+
 	public function testSendRemoveWithoutButton()
 	{
 		$response = $this->services->form->createRequest(


### PR DESCRIPTION
Remove button was broken, let’s explicitly disallow this. We should do the same for create button but for now, I am just adding incomplete test.